### PR TITLE
fixed BandDifferentialEntropy

### DIFF
--- a/torcheeg/transforms/numpy/band.py
+++ b/torcheeg/transforms/numpy/band.py
@@ -148,7 +148,7 @@ class BandDifferentialEntropy(BandTransform):
         return super().__call__(*args, eeg=eeg, baseline=baseline, **kwargs)
 
     def opt(self, eeg: np.ndarray, **kwargs) -> np.ndarray:
-        return 1 / 2 * np.log2(2 * np.pi * np.e * np.std(eeg))
+        return 1 / 2 * np.log2(2 * np.pi * np.e * np.var(eeg))
 
 
 class BandDifferentialEntropyV1(EEGTransform):


### PR DESCRIPTION
As i described in the issue i tried to correct the bug in BandDifferentialEntropy computation.

I modified the computation because the formula into the cited papers use sigma at the power of 2 that is the variance of the eeg signal and not the standard deviation.