### PR TITLE
fix: should not use inplace operator

### DIFF
--- a/torcheeg/models/gnn/dgcnn.py
+++ b/torcheeg/models/gnn/dgcnn.py
@@ -81,7 +81,7 @@ class Chebynet(nn.Module):
             if i == 0:
                 result = self.gc1[i](x, adj[i])
             else:
-                result += self.gc1[i](x, adj[i])
+                result = result+  self.gc1[i](x, adj[i])
         result = F.relu(result)
         return result
 


### PR DESCRIPTION
when I use [shap](https://github.com/shap/shap) to explain the dgcnn model (from this repository)，**have this err**:
```
Traceback (most recent call last):
  File "/home/ps/wufei/eeg-gnn-ssl/faced/single_dgcnn_EEG_TOPO_FACED_back.py", line 137, in <module>
    shap_values = explainer.shap_values(test)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/shap/explainers/_deep/__init__.py", line 136, in shap_values
    return self.explainer.shap_values(X, ranked_outputs, output_rank_order, check_additivity=check_additivity)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/shap/explainers/_deep/deep_pytorch.py", line 186, in shap_values
    sample_phis = self.gradient(feature_ind, joint_x)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/shap/explainers/_deep/deep_pytorch.py", line 101, in gradient
    outputs = self.model(*X)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/torcheeg/models/gnn/dgcnn.py", line 156, in forward
    result = self.layer1(x, L)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/torcheeg/models/gnn/dgcnn.py", line 84, in forward
    result += self.gc1[i](x, adj[i])
RuntimeError: Output 0 of BackwardHookFunctionBackward is a view and is being modified inplace. This view was created inside a custom Function (or because an input was returned as-is) and the autograd logic to handle view+inplace would override the custom backward associated with the custom Function, leading to incorrect gradients. This behavior is forbidden. You can fix this by cloning the output of the custom Function.
``` 
After my query, **this is due to the use of the inplace operation, i.e., the += operator in my change code.** So change it to **result = result + xxx** ，it works good. I think **it would be better to change to a more compatible operation here**

**chatgpt answer:**
Here, result may be a view of another tensor (or might be relying on another tensor that needs its gradients to be computed). The += operation modifies result in-place, which can corrupt the gradient computation if result is a view.
**my search reference:**
https://www.zhihu.com/question/507628087
https://discuss.pytorch.org/t/getting-this-warning-output-0-of-backwardhookfunctionbackward-is-a-view-and-is-being-modified-inplace/122766/8

Finally, it is worth mentioning that you need to change the **relu** in this line https://github.com/torcheeg/torcheeg/blob/c4ceb4aa1e9cd7f7a87c017d5c68067038d54f59/torcheeg/models/gnn/dgcnn.py#L165 
to **softmax** in order to use shap, which is supposed to be a compatibility issue of shap(very common in it's issues), not related to this repository