### PR TITLE
Wf/add faced dataset

### DIFF
--- a/docs/source/torcheeg.datasets.rst
+++ b/docs/source/torcheeg.datasets.rst
@@ -29,6 +29,7 @@ Emotion Recognition Datasets
     BCI2022Dataset
     MPEDFeatureDataset
     FACEDDataset
+    FACEDFeatureDataset
 
 Personal Identification Datasets
 ----------------------------------

--- a/docs/source/torcheeg.datasets.rst
+++ b/docs/source/torcheeg.datasets.rst
@@ -28,6 +28,7 @@ Emotion Recognition Datasets
     MAHNOBDataset
     BCI2022Dataset
     MPEDFeatureDataset
+    FACEDDataset
 
 Personal Identification Datasets
 ----------------------------------

--- a/test/datasets/test_emotion_recognition.py
+++ b/test/datasets/test_emotion_recognition.py
@@ -20,7 +20,7 @@ class TestEmotionRecognitionDataset(unittest.TestCase):
         os.mkdir('./tmp_out/')
 
     def test_faced_dataset(self):
-        io_path = f'./tmp_out/seed_v_{"".join(random.sample("zyxwvutsrqponmlkjihgfedcba", 20))}'
+        io_path = f'./tmp_out/faced_{"".join(random.sample("zyxwvutsrqponmlkjihgfedcba", 20))}'
         root_path = './tmp_in/Processed_data'
 
         dataset = FACEDDataset(io_path=io_path,
@@ -35,7 +35,7 @@ class TestEmotionRecognitionDataset(unittest.TestCase):
         self.assertEqual(last_item[0].shape, (30, 250))
 
     def test_faced_feature_dataset(self):
-        io_path = f'./tmp_out/seed_v_{"".join(random.sample("zyxwvutsrqponmlkjihgfedcba", 20))}'
+        io_path = f'./tmp_out/faced_{"".join(random.sample("zyxwvutsrqponmlkjihgfedcba", 20))}'
         root_path = './tmp_in/EEG_Features/DE'
 
         dataset = FACEDFeatureDataset(

--- a/test/datasets/test_emotion_recognition.py
+++ b/test/datasets/test_emotion_recognition.py
@@ -28,10 +28,10 @@ class TestEmotionRecognitionDataset(unittest.TestCase):
                               online_transform=transforms.ToTensor(),
                               label_transform=transforms.Select('emotion'),
                               num_worker=4)
-        self.assertEqual(len(dataset), 92988) # 123 subjects * 28 videos * (30-3)s ,3 is num_baseline
+        self.assertEqual(len(dataset), 103320) # 123 subjects * 28 videos * 30s
         first_item = dataset[0]
         self.assertEqual(first_item[0].shape, (30, 250))
-        last_item = dataset[92987]
+        last_item = dataset[103319]
         self.assertEqual(last_item[0].shape, (30, 250))
 
     def test_faced_feature_dataset(self):

--- a/test/datasets/test_emotion_recognition.py
+++ b/test/datasets/test_emotion_recognition.py
@@ -9,7 +9,7 @@ from torcheeg.datasets import (AMIGOSDataset, BCI2022Dataset, DEAPDataset,
                                MPEDFeatureDataset, SEEDDataset,
                                SEEDFeatureDataset, SEEDIVDataset,
                                SEEDIVFeatureDataset, SEEDVDataset,
-                               SEEDVFeatureDataset)
+                               SEEDVFeatureDataset,FACEDDataset,FACEDFeatureDataset)
 
 
 class TestEmotionRecognitionDataset(unittest.TestCase):
@@ -18,6 +18,38 @@ class TestEmotionRecognitionDataset(unittest.TestCase):
         if os.path.exists('./tmp_out/'):
             shutil.rmtree('./tmp_out/')
         os.mkdir('./tmp_out/')
+
+    def test_faced_dataset(self):
+        io_path = f'./tmp_out/seed_v_{"".join(random.sample("zyxwvutsrqponmlkjihgfedcba", 20))}'
+        root_path = './tmp_in/Processed_data'
+
+        dataset = FACEDDataset(io_path=io_path,
+                              root_path=root_path,
+                              online_transform=transforms.ToTensor(),
+                              label_transform=transforms.Select('emotion'),
+                              num_worker=4)
+        self.assertEqual(len(dataset), 92988) # 123 subjects * 28 videos * (30-3)s ,3 is num_baseline
+        first_item = dataset[0]
+        self.assertEqual(first_item[0].shape, (30, 250))
+        last_item = dataset[92987]
+        self.assertEqual(last_item[0].shape, (30, 250))
+
+    def test_faced_feature_dataset(self):
+        io_path = f'./tmp_out/seed_v_{"".join(random.sample("zyxwvutsrqponmlkjihgfedcba", 20))}'
+        root_path = './tmp_in/EEG_Features/DE'
+
+        dataset = FACEDFeatureDataset(
+            io_path=io_path,
+            root_path=root_path,
+            online_transform=transforms.ToTensor(),
+            label_transform=transforms.Select('emotion'),
+            num_worker=4)
+
+        self.assertEqual(len(dataset), 103320) # 123 subjects * 28 videos * 30 s
+        first_item = dataset[0]
+        self.assertEqual(first_item[0].shape, (30, 5))
+        last_item = dataset[103319]
+        self.assertEqual(last_item[0].shape, (30, 5))     
 
     def test_seed_v_dataset(self):
         io_path = f'./tmp_out/seed_v_{"".join(random.sample("zyxwvutsrqponmlkjihgfedcba", 20))}'

--- a/torcheeg/datasets/constants/emotion_recognition/__init__.py
+++ b/torcheeg/datasets/constants/emotion_recognition/__init__.py
@@ -6,3 +6,4 @@ from .seed import *
 from .seed_iv import *
 from .mped import *
 from .seed_v import *
+from .faced import *

--- a/torcheeg/datasets/constants/emotion_recognition/faced.py
+++ b/torcheeg/datasets/constants/emotion_recognition/faced.py
@@ -1,0 +1,70 @@
+from ..region_1020 import (FRONTAL_REGION_LIST, GENERAL_REGION_LIST,
+                        HEMISPHERE_REGION_LIST)
+from ..standard_1020 import STANDARD_1020_CHANNEL_LOCATION_DICT
+from ..utils import (format_adj_matrix_from_adj_list,
+                    format_adj_matrix_from_standard,
+                    format_channel_location_dict, format_region_channel_list)
+
+FACED_CHANNEL_LIST = [
+    'FP1', 'FP2', 'FZ', 'F3', 'F4', 'F7', 'F8', 'FC1', 'FC2', 'FC5', 'FC6',
+    'CZ', 'C3', 'C4', 'T7', 'T8', 'CP1', 'CP2', 'CP5', 'CP6', 'PZ', 'P3', 'P4',
+    'P7', 'P8', 'PO3', 'PO4', 'OZ', 'O1', 'O2'
+]  # and 'A2', 'A1' for left and right mastoid
+
+FACED_LOCATION_LIST = [['-', '-', '-', 'FP1', '-', 'FP2', '-', '-', '-'],
+                         ['F7', '-', 'F3', '-', 'FZ', '-', 'F4', '-', 'F8'],
+                         ['-', 'FC5', '-', 'FC1', '-', 'FC2', '-', 'FC6', '-'],
+                         ['T7', '-', 'C3', '-', 'CZ', '-', 'C4', '-', 'T8'],
+                         ['-', 'CP5', '-', 'CP1', '-', 'CP2', '-', 'CP6', '-'],
+                         ['P7', '-', 'P3', '-', 'PZ', '-', 'P4', '-', 'P8'],
+                         ['-', '-', '-', 'PO3', '-', 'PO4', '-', '-', '-'],
+                         ['-', '-', '-', 'O1', 'OZ', 'O2', '-', '-', '-']]
+
+FACED_CHANNEL_LOCATION_DICT = format_channel_location_dict(
+    FACED_CHANNEL_LIST, FACED_LOCATION_LIST)
+
+FACED_ADJACENCY_LIST = {
+    'FP1': ['F3', 'FZ'],
+    'FP2': ['FZ', 'F4'],
+    'F7': ['FC5'],
+    'F3': ['FC1', 'FC5'],
+    'FZ': ['AF4', 'FC2', 'FC1'],
+    'F4': ['AF4', 'FC6', 'FC2'],
+    'F8': ['FC6'],
+    'FC5': ['F7', 'F3', 'C3', 'T7'],
+    'FC1': ['F3', 'FZ', 'CZ', 'C3'],
+    'FC2': ['FZ', 'F4', 'C4', 'CZ'],
+    'FC6': ['F4', 'F8', 'T8', 'C4'],
+    'T7': ['FC5', 'CP5'],
+    'C3': ['FC5', 'FC1', 'CP1', 'CP5'],
+    'CZ': ['FC1', 'FC2', 'CP2', 'CP1'],
+    'C4': ['FC2', 'FC6', 'CP6', 'CP2'],
+    'T8': ['FC6', 'CP6'],
+    'CP5': ['T7', 'C3', 'P3', 'P7'],
+    'CP1': ['C3', 'CZ', 'PZ', 'P3'],
+    'CP2': ['CZ', 'C4', 'P4', 'PZ'],
+    'CP6': ['C4', 'T8', 'P8', 'P4'],
+    'P7': ['CP5'],
+    'P3': ['CP5', 'CP1', 'PO3'],
+    'PZ': ['CP1', 'CP2', 'PO4', 'PO3'],
+    'P4': ['CP2', 'CP6', 'PO4'],
+    'P8': ['CP6'],
+    'PO3': ['P3', 'PZ', 'OZ', 'O1'],
+    'PO4': ['PZ', 'P4', 'O2', 'OZ'],
+    'O1': ['PO3', 'OZ'],
+    'OZ': ['PO3', 'PO4', 'O2', 'O1'],
+    'O2': ['PO4', 'OZ']
+}
+
+FACED_ADJACENCY_MATRIX = format_adj_matrix_from_adj_list(
+    FACED_CHANNEL_LIST, FACED_ADJACENCY_LIST)
+
+FACED_STANDARD_ADJACENCY_MATRIX = format_adj_matrix_from_standard(
+    FACED_CHANNEL_LIST, STANDARD_1020_CHANNEL_LOCATION_DICT)
+
+FACED_GENERAL_REGION_LIST = format_region_channel_list(
+    FACED_CHANNEL_LIST, GENERAL_REGION_LIST)
+FACED_FRONTAL_REGION_LIST = format_region_channel_list(
+    FACED_CHANNEL_LIST, FRONTAL_REGION_LIST)
+FACED_HEMISPHERE_REGION_LIST = format_region_channel_list(
+    FACED_CHANNEL_LIST, HEMISPHERE_REGION_LIST)

--- a/torcheeg/datasets/module/base_dataset.py
+++ b/torcheeg/datasets/module/base_dataset.py
@@ -139,6 +139,8 @@ class BaseDataset(Dataset):
             records = os.listdir(io_path)
             # filter the records with the prefix '_record_'
             records = list(filter(lambda x: '_record_' in x, records))
+            # sort the records
+            records = sorted(records, key=lambda x: int(x.split('_')[2]))
 
             # for every record, get the io_path, and init the info_io and eeg_io
             eeg_io_router = {}

--- a/torcheeg/datasets/module/emotion_recognition/__init__.py
+++ b/torcheeg/datasets/module/emotion_recognition/__init__.py
@@ -11,3 +11,4 @@ from .seed_iv_feature import SEEDIVFeatureDataset
 from .seed_v import SEEDVDataset
 from .seed_v_feature import SEEDVFeatureDataset
 from .faced import FACEDDataset
+from .faced_feature import FACEDFeatureDataset

--- a/torcheeg/datasets/module/emotion_recognition/__init__.py
+++ b/torcheeg/datasets/module/emotion_recognition/__init__.py
@@ -10,3 +10,4 @@ from .seed_iv import SEEDIVDataset
 from .seed_iv_feature import SEEDIVFeatureDataset
 from .seed_v import SEEDVDataset
 from .seed_v_feature import SEEDVFeatureDataset
+from .faced import FACEDDataset

--- a/torcheeg/datasets/module/emotion_recognition/faced.py
+++ b/torcheeg/datasets/module/emotion_recognition/faced.py
@@ -1,0 +1,336 @@
+import os
+from typing import Any, Callable, Dict, Tuple, Union
+
+import pickle as pkl
+
+from ....utils import get_random_dir_path
+from ..base_dataset import BaseDataset
+
+VALENCE_DICT = {
+    1: -1,  # negative
+    2: -1,
+    3: -1,
+    4: -1,
+    5: -1,
+    6: -1,
+    7: -1,
+    8: -1,
+    9: -1,
+    10: -1,
+    11: -1,
+    12: -1,
+    13: 0,  # neutral
+    14: 0,
+    15: 0,
+    16: 0,
+    17: 1,  # positive
+    18: 1,
+    19: 1,
+    20: 1,
+    21: 1,
+    22: 1,
+    23: 1,
+    24: 1,
+    25: 1,
+    26: 1,
+    27: 1,
+    28: 1
+}
+
+EMOTION_DICT = {
+    1: 0,  # anger	
+    2: 0,
+    3: 0,
+    4: 1,  # disgust
+    5: 1,
+    6: 1,
+    7: 2,  # fear
+    8: 2,
+    9: 2,
+    10: 3,  # sadness
+    11: 3,
+    12: 3,
+    13: 4,  # neutral
+    14: 4,
+    15: 4,
+    16: 4,
+    17: 5,  # amusement
+    18: 5,
+    19: 5,
+    20: 6,  # inspiration
+    21: 6,
+    22: 6,
+    23: 7,  # joy
+    24: 7,
+    25: 7,
+    26: 8,  # tenderness
+    27: 8,
+    28: 8
+}
+
+
+class FACEDDataset(BaseDataset):
+    r'''
+    The Finer-grained Affective Computing EEG Dataset (FACED) aimed to address these issues by recording 32-channel EEG signals from 123 subjects. During the experiment, subjects watched 28 emotion-elicitation video clips covering nine emotion categories (amusement, inspiration, joy, tenderness; anger, fear, disgust, sadness, and neutral emotion), providing a fine-grained and balanced categorization on both the positive and negative sides of emotion. This class generates training samples and test samples according to the given parameters and caches the generated results in a unified input and output format (IO). The relevant information of the dataset is as follows:
+
+    - Author: Please refer to the downloaded URL.
+    - Year: 2023
+    - Download URL: https://www.synapse.org/#!Synapse:syn50614194/files/
+    - Reference: Please refer to the downloaded URL.
+    - Stimulus: video clips.
+    - Signals: Electroencephalogram (30 channels at 250Hz) and two channels of left/right mastoid signals from 123 subjects.
+    - Rating: 28 video clips are annotated in valence and discrete emotion dimensions. The valence is divided into positive (1), negative (-1), and neutral (0). Discrete emotions are divided into anger (0), disgust (1), fear (2), sadness (3), neutral (4), amusement (5), inspiration (6), joy (7), and tenderness (8).
+
+    In order to use this dataset, the download folder :obj:`Processed_data`(download from this url: https://www.synapse.org/#!Synapse:syn50615881) is required, containing the following files:
+    
+    - Processed_data
+
+        + sub000.pkl
+        + sub001.pkl
+        + sub002.pkl
+        + ...
+
+    An example dataset for CNN-based methods:
+
+    .. code-block:: python
+
+        from torcheeg.datasets import FACEDDataset
+        from torcheeg import transforms
+        from torcheeg.datasets.constants.emotion_recognition.faced import FACED_CHANNEL_LOCATION_DICT
+
+        dataset = FACEDDataset(root_path='./Processed_data',
+                                 offline_transform=transforms.Compose([
+                                     transforms.BandDifferentialEntropy(),
+                                     transforms.ToGrid(FACED_CHANNEL_LOCATION_DICT)
+                                 ]),
+                                 online_transform=transforms.ToTensor(),
+                                 label_transform=transforms.Select('emotion'))
+        print(dataset[0])
+        # EEG signal (torch.Tensor[4, 8, 9]),
+        # coresponding baseline signal (torch.Tensor[4, 8, 9]),
+        # label (int)
+
+    Another example dataset for CNN-based methods:
+
+    .. code-block:: python
+
+        from torcheeg.datasets import FACEDDataset
+        from torcheeg import transforms
+
+        dataset = FACEDDataset(root_path='./Processed_data',
+                                 online_transform=transforms.Compose(
+                                     [transforms.ToTensor(),
+                                     transforms.To2d()]),
+                                 label_transform=transforms.Select('emotion'))
+        print(dataset[0])
+        # EEG signal (torch.Tensor[1, 30, 250]),
+        # coresponding baseline signal (torch.Tensor[1, 30, 250]),
+        # label (int)
+
+    An example dataset for GNN-based methods:
+
+    .. code-block:: python
+
+        from torcheeg.datasets import FACEDDataset
+        from torcheeg import transforms
+        from torcheeg.datasets.constants.emotion_recognition.faced import FACED_ADJACENCY_MATRIX
+        from torcheeg.transforms.pyg import ToG
+
+        dataset = FACEDDataset(root_path='./Processed_data',
+                                online_transform=transforms.Compose([
+                                    ToG(FACED_ADJACENCY_MATRIX)
+                                ]),
+                                 label_transform=transforms.Select('emotion'))
+        print(dataset[0])
+        # EEG signal (torch_geometric.data.Data),
+        # coresponding baseline signal (torch_geometric.data.Data),
+        # label (int)
+
+    Args:
+        root_path (str): Downloaded data files in matlab (unzipped Processed_data.zip) formats (default: :obj:`'./Processed_data'`)
+        chunk_size (int): Number of data points included in each EEG chunk as training or test samples. If set to -1, the EEG signal of a trial is used as a sample of a chunk. (default: :obj:`250`)
+        overlap (int): The number of overlapping data points between different chunks when dividing EEG chunks. (default: :obj:`0`)
+        num_channel (int): Number of channels used, of which the first 30 channels are EEG signals. (default: :obj:`30`)
+        online_transform (Callable, optional): The transformation of the EEG signals and baseline EEG signals. The input is a :obj:`np.ndarray`, and the ouput is used as the first and second value of each element in the dataset. (default: :obj:`None`)
+        offline_transform (Callable, optional): The usage is the same as :obj:`online_transform`, but executed before generating IO intermediate results. (default: :obj:`None`)
+        label_transform (Callable, optional): The transformation of the label. The input is an information dictionary, and the ouput is used as the third value of each element in the dataset. (default: :obj:`None`)
+        before_trial (Callable, optional): The hook performed on the trial to which the sample belongs. It is performed before the offline transformation and thus typically used to implement context-dependent sample transformations, such as moving averages, etc. The input of this hook function is a 2D EEG signal with shape (number of electrodes, number of data points), whose ideal output shape is also (number of electrodes, number of data points).
+        after_trial (Callable, optional): The hook performed on the trial to which the sample belongs. It is performed after the offline transformation and thus typically used to implement context-dependent sample transformations, such as moving averages, etc. The input and output of this hook function should be a sequence of dictionaries representing a sequence of EEG samples. Each dictionary contains two key-value pairs, indexed by :obj:`eeg` (the EEG signal matrix) and :obj:`key` (the index in the database) respectively.
+        io_path (str): The path to generated unified data IO, cached as an intermediate result. If set to None, a random path will be generated. (default: :obj:`None`)
+        io_size (int): Maximum size database may grow to; used to size the memory mapping. If database grows larger than ``map_size``, an exception will be raised and the user must close and reopen. (default: :obj:`1048576`)
+        io_mode (str): Storage mode of EEG signal. When io_mode is set to :obj:`lmdb`, TorchEEG provides an efficient database (LMDB) for storing EEG signals. LMDB may not perform well on limited operating systems, where a file system based EEG signal storage is also provided. When io_mode is set to :obj:`pickle`, pickle-based persistence files are used. When io_mode is set to :obj:`memory`, memory are used. (default: :obj:`lmdb`)
+        num_worker (int): Number of subprocesses to use for data loading. 0 means that the data will be loaded in the main process. (default: :obj:`0`)
+        verbose (bool): Whether to display logs during processing, such as progress bars, etc. (default: :obj:`True`)  
+    '''
+
+    def __init__(self,
+                 root_path: str = './Processed_data',
+                 chunk_size: int = 250,
+                 overlap: int = 0,
+                 num_channel: int = 30,
+                 online_transform: Union[None, Callable] = None,
+                 offline_transform: Union[None, Callable] = None,
+                 label_transform: Union[None, Callable] = None,
+                 before_trial: Union[None, Callable] = None,
+                 after_trial: Union[Callable, None] = None,
+                 after_subject: Union[Callable, None] = None,
+                 io_path: Union[None, str] = None,
+                 io_size: int = 1048576,
+                 io_mode: str = 'lmdb',
+                 num_worker: int = 0,
+                 verbose: bool = True):
+        if io_path is None:
+            io_path = get_random_dir_path(dir_prefix='datasets')
+
+        # pass all arguments to super class
+        params = {
+            'root_path': root_path,
+            'chunk_size': chunk_size,
+            'overlap': overlap,
+            'num_channel': num_channel,
+            'online_transform': online_transform,
+            'offline_transform': offline_transform,
+            'label_transform': label_transform,
+            'before_trial': before_trial,
+            'after_trial': after_trial,
+            'after_subject': after_subject,
+            'io_path': io_path,
+            'io_size': io_size,
+            'io_mode': io_mode,
+            'num_worker': num_worker,
+            'verbose': verbose
+        }
+        super().__init__(**params)
+        # save all arguments to __dict__
+        self.__dict__.update(params)
+
+    @staticmethod
+    def process_record(file: Any = None,
+                       root_path: str = './Processed_data',
+                       chunk_size: int = 250,
+                       overlap: int = 0,
+                       num_channel: int = 30,
+                       num_baseline: int = 3,
+                       baseline_chunk_size: int = 250,
+                       before_trial: Union[None, Callable] = None,
+                       offline_transform: Union[None, Callable] = None,
+                       **kwargs):
+        file_name = os.path.basename(file)  # an element from file name list, such as 'sub087.pkl'
+        subject_id = int(file_name.split('.')[0][3:]) # get subject_id from 'sub087.pkl', such as 87
+        # derive the given arguments (kwargs)
+        with open(os.path.join(root_path, file_name), 'rb') as f:
+            samples = pkl.load(f, encoding='iso-8859-1') # 28(trials), 32(channels), 30s*250hz(time points)
+
+        write_pointer = 0
+
+        for trial_id in range(len(samples)):
+
+            # extract baseline signals
+            trial_samples = samples[
+                trial_id, :num_channel]  # 30(remove A1 and A2 from 32 channels), 30s*250hz(time points)
+            if before_trial:
+                trial_samples = before_trial(trial_samples)
+
+            trial_baseline_sample = trial_samples[:, :baseline_chunk_size *
+                                                  num_baseline]  # 30(channels), 3s*250hz(time points)
+            trial_baseline_sample = trial_baseline_sample.reshape(
+                num_channel, num_baseline,
+                baseline_chunk_size).mean(axis=1)
+
+            # record the common meta info
+
+            trial_meta_info = {
+                'subject_id': subject_id,
+                'trial_id': trial_id,
+                'valence': VALENCE_DICT[trial_id+1],
+                'emotion': EMOTION_DICT[trial_id+1],
+            }
+
+            start_at = baseline_chunk_size * num_baseline
+            if chunk_size <= 0:
+                dynamic_chunk_size = trial_samples.shape[1] - start_at
+            else:
+                dynamic_chunk_size = chunk_size
+
+            # chunk with chunk size
+            end_at = start_at + dynamic_chunk_size
+            # calculate moving step
+            step = dynamic_chunk_size - overlap
+
+            while end_at <= trial_samples.shape[1]:
+                clip_sample = trial_samples[:, start_at:end_at]
+
+                t_eeg = clip_sample
+                t_baseline = trial_baseline_sample
+
+                if not offline_transform is None:
+                    t = offline_transform(eeg=clip_sample,
+                                          baseline=trial_baseline_sample)
+                    t_eeg = t['eeg']
+                    t_baseline = t['baseline']
+
+                # put baseline signal into IO
+                if not 'baseline_id' in trial_meta_info:
+                    trial_base_id = f'{file_name}_{write_pointer}'
+                    yield {'eeg': t_baseline, 'key': trial_base_id}
+                    write_pointer += 1
+                    trial_meta_info['baseline_id'] = trial_base_id
+
+                clip_id = f'{file_name}_{write_pointer}'
+                write_pointer += 1
+
+                # record meta info for each signal
+                record_info = {
+                    'start_at': start_at,
+                    'end_at': end_at,
+                    'clip_id': clip_id
+                }
+                record_info.update(trial_meta_info)
+                yield {'eeg': t_eeg, 'key': clip_id, 'info': record_info}
+
+                start_at = start_at + step
+                end_at = start_at + dynamic_chunk_size
+
+    def set_records(self,
+                    root_path: str = './Processed_data',
+                    **kwargs):
+        assert os.path.exists(
+            root_path
+        ), f'root_path ({root_path}) does not exist. Please download the dataset and set the root_path to the downloaded path.'
+        return os.listdir(root_path)
+
+    def __getitem__(self, index: int) -> Tuple[any, any, int, int, int]:
+        info = self.read_info(index)
+
+        eeg_index = str(info['clip_id'])
+        eeg_record = str(info['_record_id'])
+        eeg = self.read_eeg(eeg_record, eeg_index)
+
+        signal = eeg
+        label = info
+
+        if self.online_transform:
+            signal = self.online_transform(eeg=eeg)['eeg']
+
+        if self.label_transform:
+            label = self.label_transform(y=info)['y']
+
+        return signal, label
+
+    @property
+    def repr_body(self) -> Dict:
+        return dict(
+            super().repr_body, **{
+                'root_path': self.root_path,
+                'chunk_size': self.chunk_size,
+                'overlap': self.overlap,
+                'num_channel': self.num_channel,
+                'online_transform': self.online_transform,
+                'offline_transform': self.offline_transform,
+                'label_transform': self.label_transform,
+                'before_trial': self.before_trial,
+                'after_trial': self.after_trial,
+                'num_worker': self.num_worker,
+                'verbose': self.verbose,
+                'io_size': self.io_size
+            })

--- a/torcheeg/datasets/module/emotion_recognition/faced.py
+++ b/torcheeg/datasets/module/emotion_recognition/faced.py
@@ -274,7 +274,9 @@ class FACEDDataset(BaseDataset):
         assert os.path.exists(
             root_path
         ), f'root_path ({root_path}) does not exist. Please download the dataset and set the root_path to the downloaded path.'
-        return os.listdir(root_path).sort()
+        paths = os.listdir(root_path)
+        paths.sort()
+        return paths
 
     def __getitem__(self, index: int) -> Tuple[any, any, int, int, int]:
         info = self.read_info(index)

--- a/torcheeg/datasets/module/emotion_recognition/faced.py
+++ b/torcheeg/datasets/module/emotion_recognition/faced.py
@@ -71,7 +71,8 @@ EMOTION_DICT = {
 
 class FACEDDataset(BaseDataset):
     r'''
-    The Finer-grained Affective Computing EEG Dataset (FACED) aimed to address these issues by recording 32-channel EEG signals from 123 subjects. During the experiment, subjects watched 28 emotion-elicitation video clips covering nine emotion categories (amusement, inspiration, joy, tenderness; anger, fear, disgust, sadness, and neutral emotion), providing a fine-grained and balanced categorization on both the positive and negative sides of emotion. This class generates training samples and test samples according to the given parameters and caches the generated results in a unified input and output format (IO). The relevant information of the dataset is as follows:
+    The FACED dataset was provided by the Tsinghua Laboratory of Brain and Intelligence. The Finer-grained Affective Computing EEG Dataset (FACED) recorded 32-channel EEG signals from 123 subjects. During the experiment, subjects watched 28 emotion-elicitation video clips covering nine emotion categories (amusement, inspiration, joy, tenderness; anger, fear, disgust, sadness, and neutral emotion), providing a fine-grained and balanced categorization on both the positive and negative sides of emotion.
+    This class generates training samples and test samples according to the given parameters, and caches the generated results in a unified input and output format (IO). The relevant information of the dataset is as follows:
 
     - Author: Please refer to the downloaded URL.
     - Year: 2023

--- a/torcheeg/datasets/module/emotion_recognition/faced.py
+++ b/torcheeg/datasets/module/emotion_recognition/faced.py
@@ -300,7 +300,7 @@ class FACEDDataset(BaseDataset):
         assert os.path.exists(
             root_path
         ), f'root_path ({root_path}) does not exist. Please download the dataset and set the root_path to the downloaded path.'
-        return os.listdir(root_path)
+        return os.listdir(root_path).sort()
 
     def __getitem__(self, index: int) -> Tuple[any, any, int, int, int]:
         info = self.read_info(index)

--- a/torcheeg/datasets/module/emotion_recognition/faced.py
+++ b/torcheeg/datasets/module/emotion_recognition/faced.py
@@ -151,6 +151,7 @@ class FACEDDataset(BaseDataset):
         chunk_size (int): Number of data points included in each EEG chunk as training or test samples. If set to -1, the EEG signal of a trial is used as a sample of a chunk. (default: :obj:`250`)
         overlap (int): The number of overlapping data points between different chunks when dividing EEG chunks. (default: :obj:`0`)
         num_channel (int): Number of channels used, of which the first 30 channels are EEG signals. (default: :obj:`30`)
+        num_baseline (int): Number of baseline signal chunks used. (default: :obj:`3`)
         online_transform (Callable, optional): The transformation of the EEG signals and baseline EEG signals. The input is a :obj:`np.ndarray`, and the ouput is used as the first and second value of each element in the dataset. (default: :obj:`None`)
         offline_transform (Callable, optional): The usage is the same as :obj:`online_transform`, but executed before generating IO intermediate results. (default: :obj:`None`)
         label_transform (Callable, optional): The transformation of the label. The input is an information dictionary, and the ouput is used as the third value of each element in the dataset. (default: :obj:`None`)
@@ -168,6 +169,7 @@ class FACEDDataset(BaseDataset):
                  chunk_size: int = 250,
                  overlap: int = 0,
                  num_channel: int = 30,
+                 num_baseline: int = 3,
                  online_transform: Union[None, Callable] = None,
                  offline_transform: Union[None, Callable] = None,
                  label_transform: Union[None, Callable] = None,
@@ -188,6 +190,7 @@ class FACEDDataset(BaseDataset):
             'chunk_size': chunk_size,
             'overlap': overlap,
             'num_channel': num_channel,
+            'num_baseline': num_baseline,
             'online_transform': online_transform,
             'offline_transform': offline_transform,
             'label_transform': label_transform,

--- a/torcheeg/datasets/module/emotion_recognition/faced_feature.py
+++ b/torcheeg/datasets/module/emotion_recognition/faced_feature.py
@@ -184,6 +184,7 @@ class FACEDFeatureDataset(BaseDataset):
         ), f'root_path ({root_path}) does not exist. Please download the dataset and set the root_path to the downloaded path.'
 
         file_path_list = os.listdir(root_path)
+        file_path_list.sort()
         file_path_list = [
             os.path.join(root_path, file_path) for file_path in file_path_list
             if file_path.endswith('.pkl')

--- a/torcheeg/datasets/module/emotion_recognition/faced_feature.py
+++ b/torcheeg/datasets/module/emotion_recognition/faced_feature.py
@@ -1,0 +1,226 @@
+import os
+import pickle as pkl
+from typing import Any, Callable, Dict, Tuple, Union
+
+import numpy as np
+
+from ....utils import get_random_dir_path
+from ..base_dataset import BaseDataset
+from .faced import VALENCE_DICT,EMOTION_DICT
+
+class FACEDFeatureDataset(BaseDataset):
+    r'''
+    The Finer-grained Affective Computing EEG Dataset (FACED) aimed to address these issues by recording 32-channel EEG signals from 123 subjects. During the experiment, subjects watched 28 emotion-elicitation video clips covering nine emotion categories (amusement, inspiration, joy, tenderness; anger, fear, disgust, sadness, and neutral emotion), providing a fine-grained and balanced categorization on both the positive and negative sides of emotion. This class generates training samples and test samples according to the given parameters and caches the generated results in a unified input and output format (IO). The relevant information of the dataset is as follows:
+
+    - Author: Please refer to the downloaded URL.
+    - Year: 2023
+    - Download URL: https://www.synapse.org/#!Synapse:syn50614194/files/
+    - Reference: Please refer to the downloaded URL.
+    - Stimulus: video clips.
+    - Signals: Electroencephalogram (30 channels at 250Hz) and two channels of left/right mastoid signals from 123 subjects.
+    - Rating: 28 video clips are annotated in valence and discrete emotion dimensions. The valence is divided into positive (1), negative (-1), and neutral (0). Discrete emotions are divided into anger (0), disgust (1), fear (2), sadness (3), neutral (4), amusement (5), inspiration (6), joy (7), and tenderness (8).
+
+    In order to use this dataset, the download folder :obj:`EEG_Features`(download from this url: https://www.synapse.org/#!Synapse:syn52368847) is required, containing the following files:
+    
+    - EEG_Features
+        - DE
+            + sub000.pkl.pkl (two .pkl is a mistake, when __init__ function is auto called, it will be renamed to sub000.pkl by func: rename_pkl_files)
+            + sub001.pkl.pkl
+            + sub002.pkl.pkl
+            + ...
+        - PSD
+            + sub000.pkl.pkl
+            + ...
+    An example dataset for CNN-based methods:
+
+    .. code-block:: python
+
+        from torcheeg.datasets import FACEDFeatureDataset
+        from torcheeg import transforms
+        from torcheeg.datasets.constants.emotion_recognition.faced import FACED_CHANNEL_LOCATION_DICT
+        
+        dataset = FACEDFeatureDataset(root_path='./EEG_Features/DE',
+                                       offline_transform=transforms.ToGrid(FACED_CHANNEL_LOCATION_DICT),
+                                       online_transform=transforms.ToTensor(),
+                                       label_transform=transforms.Select('emotion'))
+        print(dataset[0])
+        # EEG signal (torch.Tensor[5, 8, 9]),
+        # coresponding baseline signal (torch.Tensor[5, 8, 9]),
+        # label (int)
+
+    An example dataset for GNN-based methods:
+
+    .. code-block:: python
+
+        from torcheeg.datasets import FACEDFeatureDataset
+        from torcheeg import transforms
+        from torcheeg.datasets.constants.emotion_recognition.faced import FACED_ADJACENCY_MATRIX
+        from torcheeg.transforms.pyg import ToG
+        
+        dataset = FACEDFeatureDataset(root_path='./EEG_Features/DE',
+                                       online_transform=ToG(FACED_ADJACENCY_MATRIX),
+                                       label_transform=transforms.Select('emotion'))
+        print(dataset[0])
+        # EEG signal (torch_geometric.data.Data),
+        # coresponding baseline signal (torch_geometric.data.Data),
+        # label (int)
+        
+    Args:
+        root_path (str): Downloaded data files in matlab (unzipped EEG_Features.zip) formats (default: :obj:`'./EEG_Features/DE'`, optional: :obj:`'./EEG_Features/PSD'`)
+        num_channel (int): Number of channels used, of which the first 30 channels are EEG signals. (default: :obj:`30`)
+        online_transform (Callable, optional): The transformation of the EEG signals and baseline EEG signals. The input is a :obj:`np.ndarray`, and the ouput is used as the first and second value of each element in the dataset. (default: :obj:`None`)
+        offline_transform (Callable, optional): The usage is the same as :obj:`online_transform`, but executed before generating IO intermediate results. (default: :obj:`None`)
+        label_transform (Callable, optional): The transformation of the label. The input is an information dictionary, and the ouput is used as the third value of each element in the dataset. (default: :obj:`None`)
+        before_trial (Callable, optional): The hook performed on the trial to which the sample belongs. It is performed before the offline transformation and thus typically used to implement context-dependent sample transformations, such as moving averages, etc. The input of this hook function is a 3D EEG signal with shape (number of electrodes, number of windows, number of frequency bands), whose ideal output shape is also (number of electrodes, number of windows, number of frequency bands).
+        after_trial (Callable, optional): The hook performed on the trial to which the sample belongs. It is performed after the offline transformation and thus typically used to implement context-dependent sample transformations, such as moving averages, etc. The input and output of this hook function should be a sequence of dictionaries representing a sequence of EEG samples. Each dictionary contains two key-value pairs, indexed by :obj:`eeg` (the EEG signal matrix) and :obj:`key` (the index in the database) respectively.
+        io_path (str): The path to generated unified data IO, cached as an intermediate result. If set to None, a random path will be generated. (default: :obj:`None`)
+        io_size (int): Maximum size database may grow to; used to size the memory mapping. If database grows larger than ``map_size``, an exception will be raised and the user must close and reopen. (default: :obj:`1048576`)
+        io_mode (str): Storage mode of EEG signal. When io_mode is set to :obj:`lmdb`, TorchEEG provides an efficient database (LMDB) for storing EEG signals. LMDB may not perform well on limited operating systems, where a file system based EEG signal storage is also provided. When io_mode is set to :obj:`pickle`, pickle-based persistence files are used. When io_mode is set to :obj:`memory`, memory are used. (default: :obj:`lmdb`)
+        num_worker (int): Number of subprocesses to use for data loading. 0 means that the data will be loaded in the main process. (default: :obj:`0`)
+        verbose (bool): Whether to display logs during processing, such as progress bars, etc. (default: :obj:`True`)    
+    '''
+    def rename_pkl_files(self,root_path):
+        for dirpath, dirnames, filenames in os.walk(root_path):
+            for filename in filenames:
+                if filename.endswith('.pkl.pkl'):
+                    old_file_path = os.path.join(dirpath, filename)
+                    # new file name, remove the last repetitive '.pkl'
+                    new_filename = filename[:-4]
+                    new_file_path = os.path.join(dirpath, new_filename)
+                    # rename file
+                    os.rename(old_file_path, new_file_path)
+
+    def __init__(self,
+                 root_path: str = './EEG_Features/DE',
+                 num_channel: int = 30,
+                 online_transform: Union[None, Callable] = None,
+                 offline_transform: Union[None, Callable] = None,
+                 label_transform: Union[None, Callable] = None,
+                 before_trial: Union[None, Callable] = None,
+                 after_trial: Union[Callable, None] = None,
+                 after_subject: Union[Callable, None] = None,
+                 io_path: Union[None, str] = None,
+                 io_size: int = 1048576,
+                 io_mode: str = 'lmdb',
+                 num_worker: int = 0,
+                 verbose: bool = True):
+        if io_path is None:
+            io_path = get_random_dir_path(dir_prefix='datasets')
+        self.rename_pkl_files(root_path)
+        # pass all arguments to super class
+        params = {
+            'root_path': root_path,
+            'num_channel': num_channel,
+            'online_transform': online_transform,
+            'offline_transform': offline_transform,
+            'label_transform': label_transform,
+            'before_trial': before_trial,
+            'after_trial': after_trial,
+            'after_subject': after_subject,
+            'io_path': io_path,
+            'io_size': io_size,
+            'io_mode': io_mode,
+            'num_worker': num_worker,
+            'verbose': verbose
+        }
+        super().__init__(**params)
+        # save all arguments to __dict__
+        self.__dict__.update(params)
+
+    @staticmethod
+    def process_record(num_channel: int = 30,
+                       offline_transform: Union[None, Callable] = None,
+                       before_trial: Union[None, Callable] = None,
+                       file: Any = None,
+                       **kwargs):
+        # get file name from path ,such as 'sub087.pkl'
+        file_name = os.path.basename(file)
+
+        subject_id = int(file_name.split('.')[0][3:]) # get int value from 'sub087.pkl', such as 87
+
+        # load the file
+        with open(os.path.join(file), 'rb') as f:
+            data = pkl.load(f, encoding='iso-8859-1') # 28(trials), 32(channels), 30s(time points), 5(frequency bands)
+
+        write_pointer = 0
+
+        # loop all trials
+        for trial_id in range(len(data)):
+            trial_samples = data[trial_id,:num_channel] # 30(channels), 30s(time points), 5(frequency bands)
+
+            trial_meta_info = {
+                'subject_id': subject_id,
+                'trial_id': trial_id
+            }
+
+            if before_trial:
+                trial_samples = before_trial(trial_samples)
+
+            # loop all clips
+            for i in range(trial_samples.shape[1]):
+                t_eeg = trial_samples[:,i]
+
+                clip_id = f'{file_name}_{write_pointer}'
+                write_pointer += 1
+
+                record_info = {
+                    'start_at': i * 250,
+                    'end_at': (i + 1) *
+                    250,  # The size of the sliding time windows for feature 
+                    'clip_id': clip_id,
+                    'valence': VALENCE_DICT[trial_id+1],
+                    'emotion': EMOTION_DICT[trial_id+1],
+                }
+                record_info.update(trial_meta_info)
+
+                if not offline_transform is None:
+                    t_eeg = offline_transform(eeg=t_eeg)['eeg']
+
+                yield {'eeg': t_eeg, 'key': clip_id, 'info': record_info}
+
+    def set_records(self, root_path: str = './EEG_Features/DE', **kwargs):
+        assert os.path.exists(
+            root_path
+        ), f'root_path ({root_path}) does not exist. Please download the dataset and set the root_path to the downloaded path.'
+
+        file_path_list = os.listdir(root_path)
+        file_path_list = [
+            os.path.join(root_path, file_path) for file_path in file_path_list
+            if file_path.endswith('.pkl')
+        ]
+
+        return file_path_list
+
+    def __getitem__(self, index: int) -> Tuple[any, any, int, int, int]:
+        info = self.read_info(index)
+
+        eeg_index = str(info['clip_id'])
+        eeg_record = str(info['_record_id'])
+        eeg = self.read_eeg(eeg_record, eeg_index)
+
+        signal = eeg
+        label = info
+
+        if self.online_transform:
+            signal = self.online_transform(eeg=eeg)['eeg']
+
+        if self.label_transform:
+            label = self.label_transform(y=info)['y']
+
+        return signal, label
+
+    @property
+    def repr_body(self) -> Dict:
+        return dict(
+            super().repr_body, **{
+                'root_path': self.root_path,
+                'num_channel': self.num_channel,
+                'online_transform': self.online_transform,
+                'offline_transform': self.offline_transform,
+                'label_transform': self.label_transform,
+                'before_trial': self.before_trial,
+                'after_trial': self.after_trial,
+                'num_worker': self.num_worker,
+                'verbose': self.verbose,
+                'io_size': self.io_size
+            })

--- a/torcheeg/datasets/module/emotion_recognition/faced_feature.py
+++ b/torcheeg/datasets/module/emotion_recognition/faced_feature.py
@@ -10,7 +10,8 @@ from .faced import VALENCE_DICT,EMOTION_DICT
 
 class FACEDFeatureDataset(BaseDataset):
     r'''
-    The Finer-grained Affective Computing EEG Dataset (FACED) aimed to address these issues by recording 32-channel EEG signals from 123 subjects. During the experiment, subjects watched 28 emotion-elicitation video clips covering nine emotion categories (amusement, inspiration, joy, tenderness; anger, fear, disgust, sadness, and neutral emotion), providing a fine-grained and balanced categorization on both the positive and negative sides of emotion. This class generates training samples and test samples according to the given parameters and caches the generated results in a unified input and output format (IO). The relevant information of the dataset is as follows:
+    The FACED dataset was provided by the Tsinghua Laboratory of Brain and Intelligence. The Finer-grained Affective Computing EEG Dataset (FACED) recorded 32-channel EEG signals from 123 subjects. During the experiment, subjects watched 28 emotion-elicitation video clips covering nine emotion categories (amusement, inspiration, joy, tenderness; anger, fear, disgust, sadness, and neutral emotion), providing a fine-grained and balanced categorization on both the positive and negative sides of emotion.
+    This class generates training samples and test samples according to the given parameters, and caches the generated results in a unified input and output format (IO). The relevant information of the dataset is as follows:
 
     - Author: Please refer to the downloaded URL.
     - Year: 2023


### PR DESCRIPTION
@tczhangzhi 
I add the [FACED](https://www.synapse.org/#!Synapse:syn50614194/wiki/620378) and FACEDFeature dataset. The number of subjects, number of movies, channels, etc. of this dataset are basically consistent with BCI2022Dataset.
I test my code:

- in the test code I added in test/datasets/test_emotion_recognition.py.

- the examples in the class definition comments:
<img src="https://github.com/torcheeg/torcheeg/assets/63766429/bf129b1e-add4-4417-b885-505dccc078b0" width="650px">

- I compare the element-by-element of the faced and feature dataset with the x's I get from reading the raw file directly to make sure each element is correct：
code like this:
```
    dataset = FACEDDataset(io_path=f'./de/test_faced',
                      root_path='/home/wufei/github.com/wufei-png/torcheeg/faced_dataset/Processed_data',
                      num_channel=32,
                      num_baseline=0,
        label_transform=transforms.Select('emotion'))
    print("len(dataset)",len(dataset))
    raw_data=pickle.load(open('/home/wufei/gitee.com/ai_lab/eeg-gnn-ssl/faced_data.pkl', 'rb'))
    print(raw_data.shape,raw_data.dtype)
    for idx,x in enumerate(dataset):
        if np.array_equal(x[0], raw_data[idx])==False:
            print("idx",idx)
            raise ValueError("not equal")
    print("equal")
```

**All of them works well.**

When I do the last step of the test (element-by-element compare): I found I must first **sort** the dataset like this commit：
[feat: sort dataset by file name](https://github.com/torcheeg/torcheeg/pull/108/commits/209e582c329002246f46c990fd7c88fc11399008).
I think **torcheeg/model_selection package should do whether shuffle instead of the dataset itself.** So sort the dataset first by something such as person id to make dataset ordered is reasonable, and also convenient to verify the correctness of the data. 
