### PR TITLE
fix hann import issue from scipy lib

### DIFF
--- a/torcheeg/transforms/numpy/band.py
+++ b/torcheeg/transforms/numpy/band.py
@@ -1,6 +1,6 @@
 from typing import Dict, Tuple, Union
-
-from scipy.signal import butter, hann, lfilter
+from scipy.signal.windows import hann 
+from scipy.signal import butter, lfilter
 
 import numpy as np
 

--- a/torcheeg/transforms/numpy/band_pyeeg.py
+++ b/torcheeg/transforms/numpy/band_pyeeg.py
@@ -1,5 +1,6 @@
 from typing import Dict, Tuple, Union
-from scipy.signal import butter, lfilter, hann
+from scipy.signal.windows import hann 
+from scipy.signal import butter, lfilter
 
 import numpy as np
 


### PR DESCRIPTION
currently using scipy v1.7.3 , torcheeg v1.1.2
prior issue : from torcheeg import transforms not working #123

import error debug
![Screenshot from 2024-09-20 16-42-52](https://github.com/user-attachments/assets/a87f613e-0971-45f0-bca7-ab9e4e7ace42)
