### PR TITLE
Fix typo in assert statement for studies

### DIFF
--- a/torcheeg/datasets/module/sleep_stage_detection/sleep_edfx.py
+++ b/torcheeg/datasets/module/sleep_stage_detection/sleep_edfx.py
@@ -136,7 +136,7 @@ class SleepEDFxDataset(BaseDataset):
         if io_path is None:
             io_path = get_random_dir_path(dir_prefix='datasets')
 
-        assert 'casstte' in studies or 'telemetry' in studies, 'studies must contain either "cassette" or "telemetry"'
+        assert 'cassette' in studies or 'telemetry' in studies, 'studies must contain either "cassette" or "telemetry"'
 
         params = {
             'root_path': root_path,


### PR DESCRIPTION
Resolve the typo `casstte` and update to `cassette`.

This typo causes failure in importing SleepEDFxDataset class.